### PR TITLE
Refactor RestaurantList to use loader data rather than props

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -7,18 +7,19 @@ import RestaurantList from './RestaurantList';
 function App() {
   const [restaurants, setRestaurants] = useState([]);
 
-  useEffect(() => {
-    fetch("http://127.0.0.1:5555/restaurants")
-    .then(r => r.json())
-    .then((d) => setRestaurants(d))
-    .catch((error) => console.error('Error fetching data:', error));
-  }, []);
+  // useEffect(() => {
+  //   fetch("http://127.0.0.1:5555/restaurants")
+  //   .then(r => r.json())
+  //   .then((d) => setRestaurants(d))
+  //   .catch((error) => console.error('Error fetching data:', error));
+  // }, []);
 
   return (
     <>
       <Header />
       <div id="main">
-        <RestaurantList restaurants={restaurants}/>
+        {/* <RestaurantList restaurants={restaurants}/> */}
+        <RestaurantList />
         <RestaurantMap />
       </div>
     </>

--- a/client/src/RestaurantList.jsx
+++ b/client/src/RestaurantList.jsx
@@ -1,24 +1,17 @@
 import React from 'react';
 import RestaurantCard from './RestaurantCard';
-import { useLoaderData } from "react-router-dom"
+import { useLoaderData } from 'react-router-dom';
 
-
-function RestaurantList({restaurants}) {
-  let allRestaurants = useLoaderData()
-  if (restaurants) { allRestaurants = restaurants }
-  function populateList(restaurants) {
-
-  const result = [];
-  for (let restaurant of restaurants) {
-    result.push(<RestaurantCard restaurant={restaurant} key={restaurant.id} />);
-  }
-  return result
-}
+function RestaurantList() {
+  let allRestaurants = useLoaderData();
 
   return (
     <div>
-      {populateList(allRestaurants)}
-    </div>)
+      {allRestaurants.map((rest) => (
+        <RestaurantCard restaurant={rest} />
+      ))}
+    </div>
+  );
 }
 
 export default RestaurantList;

--- a/client/src/loaders.js
+++ b/client/src/loaders.js
@@ -1,10 +1,8 @@
 async function restaurantListLoader({ request, params }) {
-    const res = await fetch("http://127.0.0.1:5555/restaurants")
-      .then(resp => resp.json())
-    return res
-  }
-
-export {
-    restaurantListLoader
+  const res = await fetch('http://127.0.0.1:5555/restaurants').then((resp) =>
+    resp.json()
+  );
+  return res;
 }
 
+export { restaurantListLoader };

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,32 +1,27 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import {
-  createBrowserRouter,
-  RouterProvider,
-} from "react-router-dom";
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import App from './App.jsx';
 import RestaurantList from './RestaurantList';
 
-import {
-  restaurantListLoader
-} from './loaders.js'
-
+import { restaurantListLoader } from './loaders.js';
 
 const router = createBrowserRouter([
   {
-    path:"/", // this is the path for our route
-    element: <App /> // component we want to render for this route
+    path: '/', // this is the path for our route
+    element: <App />, // component we want to render for this route
+    loader: restaurantListLoader,
   },
   {
-    path:"/restaurants",
+    path: '/restaurants',
     element: <RestaurantList />,
-    loader: restaurantListLoader
-  }
-])
+    loader: restaurantListLoader,
+  },
+]);
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <RouterProvider router={router} /> 
+    <RouterProvider router={router} />
   </React.StrictMode>
 );


### PR DESCRIPTION
We were passing down the restaurant list as a prop on the '/' route, and Ben helped us set up useLoaderData on the '/restaurants' route. I refactored the code to use the loader method in both places to keep it simpler.